### PR TITLE
Fix `RawOccupiedEntryMut::into_key`, release 2.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.2.0"
+version = "2.2.1"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+- 2.2.1
+
+  - Corrected the signature of `RawOccupiedEntryMut::into_key(self) -> &'a mut K`,
+    This a breaking change from 2.2.0, but that version was published for less
+    than a day and has now been yanked.
+
 - 2.2.0
 
   - The new `IndexMap::get_index_entry` method finds an entry by its index for

--- a/src/map/core/raw_entry_v1.rs
+++ b/src/map/core/raw_entry_v1.rs
@@ -384,8 +384,8 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
     /// Note that this is not the key that was used to find the entry. There may be an observable
     /// difference if the key type has any distinguishing features outside of `Hash` and `Eq`, like
     /// extra fields or the memory address of an allocation.
-    pub fn into_key(&mut self) -> &mut K {
-        &mut self.raw.bucket_mut().key
+    pub fn into_key(self) -> &'a mut K {
+        &mut self.raw.into_bucket().key
     }
 
     /// Gets a reference to the entry's value in the map.


### PR DESCRIPTION
This was a bad copy-paste error from `key_mut`. While this is a breaking change, it has been short enough time that I'm going to treat this as a bug fix. I already yanked 2.2.0 as well.