### PR TITLE
Add indexing methods to raw entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.2.1"
+version = "2.2.2"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+- 2.2.2
+
+  - Added indexing methods to raw entries: `RawEntryBuilder::from_hash_full`,
+    `RawEntryBuilder::index_from_hash`, and `RawEntryMut::index`.
+
 - 2.2.1
 
   - Corrected the signature of `RawOccupiedEntryMut::into_key(self) -> &'a mut K`,


### PR DESCRIPTION
The `std`-matching methods of `RawEntryBuilder` only return `(&K, &V)`,
but the index is also useful when working with `IndexMap`.

```rust
impl<'a, K, V, S> RawEntryBuilder<'a, K, V, S> {
    /// Access an entry by hash, including its index.
    pub fn from_hash_full<F>(self, hash: u64, is_match: F) -> Option<(usize, &'a K, &'a V)>
    where
        F: FnMut(&K) -> bool,

    /// Access the index of an entry by hash.
    pub fn index_from_hash<F>(self, hash: u64, is_match: F) -> Option<usize>
    where
        F: FnMut(&K) -> bool,
}
```

In addition, the `RawEntryMut` enum can report its index by forwarding
to the existing methods on its variants.

```rust
impl<'a, K, V, S> RawEntryMut<'a, K, V, S> {
    /// Return the index where the key-value pair exists or may be inserted.
    pub fn index(&self) -> usize
}
```
