### PR TITLE
Add more indexed methods to entries

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -26,6 +26,7 @@ pub use crate::rayon::map as rayon;
 use ::core::cmp::Ordering;
 use ::core::fmt;
 use ::core::hash::{BuildHasher, Hash, Hasher};
+use ::core::mem;
 use ::core::ops::{Index, IndexMut, RangeBounds};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -380,14 +381,14 @@ where
     ///
     /// If an equivalent key already exists in the map: the key remains and
     /// retains in its place in the order, its corresponding value is updated
-    /// with `value` and the older value is returned inside `Some(_)`.
+    /// with `value`, and the older value is returned inside `Some(_)`.
     ///
     /// If no equivalent key existed in the map: the new key-value pair is
     /// inserted, last in order, and `None` is returned.
     ///
     /// Computes in **O(1)** time (amortized average).
     ///
-    /// See also [`entry`][Self::entry] if you you want to insert *or* modify,
+    /// See also [`entry`][Self::entry] if you want to insert *or* modify,
     /// or [`insert_full`][Self::insert_full] if you need to get the index of
     /// the corresponding key-value pair.
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
@@ -398,17 +399,46 @@ where
     ///
     /// If an equivalent key already exists in the map: the key remains and
     /// retains in its place in the order, its corresponding value is updated
-    /// with `value` and the older value is returned inside `(index, Some(_))`.
+    /// with `value`, and the older value is returned inside `(index, Some(_))`.
     ///
     /// If no equivalent key existed in the map: the new key-value pair is
     /// inserted, last in order, and `(index, None)` is returned.
     ///
     /// Computes in **O(1)** time (amortized average).
     ///
-    /// See also [`entry`][Self::entry] if you you want to insert *or* modify.
+    /// See also [`entry`][Self::entry] if you want to insert *or* modify.
     pub fn insert_full(&mut self, key: K, value: V) -> (usize, Option<V>) {
         let hash = self.hash(&key);
         self.core.insert_full(hash, key, value)
+    }
+
+    /// Insert a key-value pair in the map at the given index.
+    ///
+    /// If an equivalent key already exists in the map: the key remains and
+    /// is moved to the new position in the map, its corresponding value is updated
+    /// with `value`, and the older value is returned inside `Some(_)`.
+    ///
+    /// If no equivalent key existed in the map: the new key-value pair is
+    /// inserted at the given index, and `None` is returned.
+    ///
+    /// ***Panics*** if `index` is out of bounds.
+    ///
+    /// Computes in **O(n)** time (average).
+    ///
+    /// See also [`entry`][Self::entry] if you want to insert *or* modify,
+    /// perhaps only using the index for new entries with [`VacantEntry::shift_insert`].
+    pub fn shift_insert(&mut self, index: usize, key: K, value: V) -> Option<V> {
+        match self.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let old = mem::replace(entry.get_mut(), value);
+                entry.move_index(index);
+                Some(old)
+            }
+            Entry::Vacant(entry) => {
+                entry.shift_insert(index, value);
+                None
+            }
+        }
     }
 
     /// Get the given key’s corresponding entry in the map for insertion and/or

--- a/src/map.rs
+++ b/src/map.rs
@@ -1051,6 +1051,8 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Swaps the position of two key-value pairs in the map.
     ///
     /// ***Panics*** if `a` or `b` are out of bounds.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn swap_indices(&mut self, a: usize, b: usize) {
         self.core.swap_indices(a, b)
     }

--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -241,6 +241,9 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// Moves the position of the entry to a new index
     /// by shifting all other entries in-between.
     ///
+    /// This is equivalent to [`IndexMap::move_index`][`crate::IndexMap::move_index`]
+    /// coming `from` the current [`.index()`][Self::index].
+    ///
     /// * If `self.index() < to`, the other pairs will shift down while the targeted pair moves up.
     /// * If `self.index() > to`, the other pairs will shift up while the targeted pair moves down.
     ///
@@ -253,6 +256,9 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     }
 
     /// Swaps the position of entry with another.
+    ///
+    /// This is equivalent to [`IndexMap::swap_indices`][`crate::IndexMap::swap_indices`]
+    /// with the current [`.index()`][Self::index] as one of the two being swapped.
     ///
     /// ***Panics*** if the `other` index is out of bounds.
     ///
@@ -420,6 +426,9 @@ impl<'a, K, V> IndexedEntry<'a, K, V> {
     /// Moves the position of the entry to a new index
     /// by shifting all other entries in-between.
     ///
+    /// This is equivalent to [`IndexMap::move_index`][`crate::IndexMap::move_index`]
+    /// coming `from` the current [`.index()`][Self::index].
+    ///
     /// * If `self.index() < to`, the other pairs will shift down while the targeted pair moves up.
     /// * If `self.index() > to`, the other pairs will shift up while the targeted pair moves down.
     ///
@@ -431,6 +440,9 @@ impl<'a, K, V> IndexedEntry<'a, K, V> {
     }
 
     /// Swaps the position of entry with another.
+    ///
+    /// This is equivalent to [`IndexMap::swap_indices`][`crate::IndexMap::swap_indices`]
+    /// with the current [`.index()`][Self::index] as one of the two being swapped.
     ///
     /// ***Panics*** if the `other` index is out of bounds.
     ///

--- a/src/map/core/raw.rs
+++ b/src/map/core/raw.rs
@@ -142,4 +142,10 @@ impl<'a, K, V> RawTableEntry<'a, K, V> {
         let (index, _slot) = unsafe { self.map.indices.remove(self.raw_bucket) };
         (self.map, index)
     }
+
+    /// Take no action, just return the index and the original map reference.
+    pub(super) fn into_inner(self) -> (&'a mut IndexMapCore<K, V>, usize) {
+        let index = self.index();
+        (self.map, index)
+    }
 }

--- a/src/map/core/raw_entry_v1.rs
+++ b/src/map/core/raw_entry_v1.rs
@@ -543,6 +543,9 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
     /// Moves the position of the entry to a new index
     /// by shifting all other entries in-between.
     ///
+    /// This is equivalent to [`IndexMap::move_index`]
+    /// coming `from` the current [`.index()`][Self::index].
+    ///
     /// * If `self.index() < to`, the other pairs will shift down while the targeted pair moves up.
     /// * If `self.index() > to`, the other pairs will shift up while the targeted pair moves down.
     ///
@@ -555,6 +558,9 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
     }
 
     /// Swaps the position of entry with another.
+    ///
+    /// This is equivalent to [`IndexMap::swap_indices`]
+    /// with the current [`.index()`][Self::index] as one of the two being swapped.
     ///
     /// ***Panics*** if the `other` index is out of bounds.
     ///

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -125,6 +125,14 @@ fn shift_insert() {
     for (i, k) in (0..insert.len()).zip(map.keys()) {
         assert_eq!(map.get_index(i).unwrap().0, k);
     }
+
+    // "insert" that moves an existing entry
+    map.shift_insert(0, insert[0], ());
+    assert_eq!(map.keys().count(), insert.len());
+    assert_eq!(insert[0], map.keys()[0]);
+    for (a, b) in insert[1..].iter().rev().zip(map.keys().skip(1)) {
+        assert_eq!(a, b);
+    }
 }
 
 #[test]

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -109,6 +109,25 @@ fn insert_order() {
 }
 
 #[test]
+fn shift_insert() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
+    let mut map = IndexMap::new();
+
+    for &elt in &insert {
+        map.shift_insert(0, elt, ());
+    }
+
+    assert_eq!(map.keys().count(), map.len());
+    assert_eq!(map.keys().count(), insert.len());
+    for (a, b) in insert.iter().rev().zip(map.keys()) {
+        assert_eq!(a, b);
+    }
+    for (i, k) in (0..insert.len()).zip(map.keys()) {
+        assert_eq!(map.get_index(i).unwrap().0, k);
+    }
+}
+
+#[test]
 fn grow() {
     let insert = [0, 4, 2, 12, 8, 7, 11];
     let not_present = [1, 3, 6, 9, 10];

--- a/src/set.rs
+++ b/src/set.rs
@@ -353,6 +353,20 @@ where
         (index, existing.is_none())
     }
 
+    /// Insert the value into the set at the given index.
+    ///
+    /// If an equivalent item already exists in the set, it returns
+    /// `false` leaving the original value in the set, but moving it to
+    /// the new position in the set. Otherwise, it inserts the new
+    /// item at the given index and returns `true`.
+    ///
+    /// ***Panics*** if `index` is out of bounds.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn shift_insert(&mut self, index: usize, value: T) -> bool {
+        self.map.shift_insert(index, value, ()).is_none()
+    }
+
     /// Adds a value to the set, replacing the existing value, if any, that is
     /// equal to the given one, without altering its insertion order. Returns
     /// the replaced value.

--- a/src/set.rs
+++ b/src/set.rs
@@ -902,6 +902,8 @@ impl<T, S> IndexSet<T, S> {
     /// Swaps the position of two values in the set.
     ///
     /// ***Panics*** if `a` or `b` are out of bounds.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn swap_indices(&mut self, a: usize, b: usize) {
         self.map.swap_indices(a, b)
     }

--- a/src/set/tests.rs
+++ b/src/set/tests.rs
@@ -144,6 +144,14 @@ fn shift_insert() {
     for (i, v) in (0..insert.len()).zip(set.iter()) {
         assert_eq!(set.get_index(i).unwrap(), v);
     }
+
+    // "insert" that moves an existing entry
+    set.shift_insert(0, insert[0]);
+    assert_eq!(set.iter().count(), insert.len());
+    assert_eq!(insert[0], set[0]);
+    for (a, b) in insert[1..].iter().rev().zip(set.iter().skip(1)) {
+        assert_eq!(a, b);
+    }
 }
 
 #[test]

--- a/src/set/tests.rs
+++ b/src/set/tests.rs
@@ -128,6 +128,25 @@ fn insert_order() {
 }
 
 #[test]
+fn shift_insert() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5, 3, 17, 19, 22, 23];
+    let mut set = IndexSet::new();
+
+    for &elt in &insert {
+        set.shift_insert(0, elt);
+    }
+
+    assert_eq!(set.iter().count(), set.len());
+    assert_eq!(set.iter().count(), insert.len());
+    for (a, b) in insert.iter().rev().zip(set.iter()) {
+        assert_eq!(a, b);
+    }
+    for (i, v) in (0..insert.len()).zip(set.iter()) {
+        assert_eq!(set.get_index(i).unwrap(), v);
+    }
+}
+
+#[test]
 fn replace() {
     let replace = [0, 4, 2, 12, 8, 7, 11, 5];
     let not_present = [1, 3, 6, 9, 10];

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -19,8 +19,8 @@ use std::hash::Hash;
 use std::ops::Bound;
 use std::ops::Deref;
 
-use indexmap::map::Entry as OEntry;
-use std::collections::hash_map::Entry as HEntry;
+use indexmap::map::Entry;
+use std::collections::hash_map::Entry as StdEntry;
 
 fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
 where
@@ -248,7 +248,7 @@ quickcheck_limit! {
         test_map_swap_indices(vec, from, to, |map, from, to| {
             let key = map.keys()[from];
             match map.entry(key) {
-                OEntry::Occupied(entry) => entry.swap_indices(to),
+                Entry::Occupied(entry) => entry.swap_indices(to),
                 _ => unreachable!(),
             }
         })
@@ -303,7 +303,7 @@ quickcheck_limit! {
         test_map_move_index(vec, from, to, |map, from, to| {
             let key = map.keys()[from];
             match map.entry(key) {
-                OEntry::Occupied(entry) => entry.move_index(to),
+                Entry::Occupied(entry) => entry.move_index(to),
                 _ => unreachable!(),
             }
         })
@@ -329,7 +329,7 @@ quickcheck_limit! {
     fn occupied_entry_shift_insert(vec: Vec<u8>, i: u8) -> TestResult {
         test_map_shift_insert(vec, i, |map, i, key| {
             match map.entry(key) {
-                OEntry::Vacant(entry) => entry.shift_insert(i, ()),
+                Entry::Vacant(entry) => entry.shift_insert(i, ()),
                 _ => unreachable!(),
             };
         })
@@ -473,10 +473,10 @@ where
                 b.remove(k);
             }
             RemoveEntry(ref k) => {
-                if let OEntry::Occupied(ent) = a.entry(k.clone()) {
+                if let Entry::Occupied(ent) = a.entry(k.clone()) {
                     ent.swap_remove_entry();
                 }
-                if let HEntry::Occupied(ent) = b.entry(k.clone()) {
+                if let StdEntry::Occupied(ent) = b.entry(k.clone()) {
                     ent.remove_entry();
                 }
             }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -218,7 +218,7 @@ quickcheck_limit! {
     }
 
     // Use `u8` test indices so quickcheck is less likely to go out of bounds.
-    fn swap_indices(vec: Vec<u8>, a: u8, b: u8) -> TestResult {
+    fn set_swap_indices(vec: Vec<u8>, a: u8, b: u8) -> TestResult {
         let mut set = IndexSet::<u8>::from_iter(vec);
         let a = usize::from(a);
         let b = usize::from(b);
@@ -240,8 +240,39 @@ quickcheck_limit! {
         TestResult::passed()
     }
 
+    fn map_swap_indices(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_swap_indices(vec, from, to, IndexMap::swap_indices)
+    }
+
+    fn occupied_entry_swap_indices(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_swap_indices(vec, from, to, |map, from, to| {
+            let key = map.keys()[from];
+            match map.entry(key) {
+                OEntry::Occupied(entry) => entry.swap_indices(to),
+                _ => unreachable!(),
+            }
+        })
+    }
+
+    fn indexed_entry_swap_indices(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_swap_indices(vec, from, to, |map, from, to| {
+            map.get_index_entry(from).unwrap().swap_indices(to);
+        })
+    }
+
+    fn raw_occupied_entry_swap_indices(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        use indexmap::map::raw_entry_v1::{RawEntryApiV1, RawEntryMut};
+        test_map_swap_indices(vec, from, to, |map, from, to| {
+            let key = map.keys()[from];
+            match map.raw_entry_mut_v1().from_key(&key) {
+                RawEntryMut::Occupied(entry) => entry.swap_indices(to),
+                _ => unreachable!(),
+            }
+        })
+    }
+
     // Use `u8` test indices so quickcheck is less likely to go out of bounds.
-    fn move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+    fn set_move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
         let mut set = IndexSet::<u8>::from_iter(vec);
         let from = usize::from(from);
         let to = usize::from(to);
@@ -263,6 +294,138 @@ quickcheck_limit! {
         }));
         TestResult::passed()
     }
+
+    fn map_move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_move_index(vec, from, to, IndexMap::move_index)
+    }
+
+    fn occupied_entry_move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_move_index(vec, from, to, |map, from, to| {
+            let key = map.keys()[from];
+            match map.entry(key) {
+                OEntry::Occupied(entry) => entry.move_index(to),
+                _ => unreachable!(),
+            }
+        })
+    }
+
+    fn indexed_entry_move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        test_map_move_index(vec, from, to, |map, from, to| {
+            map.get_index_entry(from).unwrap().move_index(to);
+        })
+    }
+
+    fn raw_occupied_entry_move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
+        use indexmap::map::raw_entry_v1::{RawEntryApiV1, RawEntryMut};
+        test_map_move_index(vec, from, to, |map, from, to| {
+            let key = map.keys()[from];
+            match map.raw_entry_mut_v1().from_key(&key) {
+                RawEntryMut::Occupied(entry) => entry.move_index(to),
+                _ => unreachable!(),
+            }
+        })
+    }
+
+    fn occupied_entry_shift_insert(vec: Vec<u8>, i: u8) -> TestResult {
+        test_map_shift_insert(vec, i, |map, i, key| {
+            match map.entry(key) {
+                OEntry::Vacant(entry) => entry.shift_insert(i, ()),
+                _ => unreachable!(),
+            };
+        })
+    }
+
+    fn raw_occupied_entry_shift_insert(vec: Vec<u8>, i: u8) -> TestResult {
+        use indexmap::map::raw_entry_v1::{RawEntryApiV1, RawEntryMut};
+        test_map_shift_insert(vec, i, |map, i, key| {
+            match map.raw_entry_mut_v1().from_key(&key) {
+                RawEntryMut::Vacant(entry) => entry.shift_insert(i, key, ()),
+                _ => unreachable!(),
+            };
+        })
+    }
+}
+
+fn test_map_swap_indices<F>(vec: Vec<u8>, a: u8, b: u8, swap_indices: F) -> TestResult
+where
+    F: FnOnce(&mut IndexMap<u8, ()>, usize, usize),
+{
+    let mut map = IndexMap::<u8, ()>::from_iter(vec.into_iter().map(|k| (k, ())));
+    let a = usize::from(a);
+    let b = usize::from(b);
+
+    if a >= map.len() || b >= map.len() {
+        return TestResult::discard();
+    }
+
+    let mut vec = Vec::from_iter(map.keys().copied());
+    vec.swap(a, b);
+
+    swap_indices(&mut map, a, b);
+
+    // Check both iteration order and hash lookups
+    assert!(map.keys().eq(vec.iter()));
+    assert!(vec
+        .iter()
+        .enumerate()
+        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    TestResult::passed()
+}
+
+fn test_map_move_index<F>(vec: Vec<u8>, from: u8, to: u8, move_index: F) -> TestResult
+where
+    F: FnOnce(&mut IndexMap<u8, ()>, usize, usize),
+{
+    let mut map = IndexMap::<u8, ()>::from_iter(vec.into_iter().map(|k| (k, ())));
+    let from = usize::from(from);
+    let to = usize::from(to);
+
+    if from >= map.len() || to >= map.len() {
+        return TestResult::discard();
+    }
+
+    let mut vec = Vec::from_iter(map.keys().copied());
+    let x = vec.remove(from);
+    vec.insert(to, x);
+
+    move_index(&mut map, from, to);
+
+    // Check both iteration order and hash lookups
+    assert!(map.keys().eq(vec.iter()));
+    assert!(vec
+        .iter()
+        .enumerate()
+        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    TestResult::passed()
+}
+
+fn test_map_shift_insert<F>(vec: Vec<u8>, i: u8, shift_insert: F) -> TestResult
+where
+    F: FnOnce(&mut IndexMap<u8, ()>, usize, u8),
+{
+    let mut map = IndexMap::<u8, ()>::from_iter(vec.into_iter().map(|k| (k, ())));
+    let i = usize::from(i);
+    if i >= map.len() {
+        return TestResult::discard();
+    }
+
+    let mut vec = Vec::from_iter(map.keys().copied());
+    let x = vec.pop().unwrap();
+    vec.insert(i, x);
+
+    let (last, ()) = map.pop().unwrap();
+    assert_eq!(x, last);
+    map.shrink_to_fit(); // so we might have to grow and rehash the table
+
+    shift_insert(&mut map, i, last);
+
+    // Check both iteration order and hash lookups
+    assert!(map.keys().eq(vec.iter()));
+    assert!(vec
+        .iter()
+        .enumerate()
+        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    TestResult::passed()
 }
 
 use crate::Op::*;


### PR DESCRIPTION
For `IndexedEntry`, `OccupiedEntry`, and `RawOccupiedEntryMut`, this
adds `move_index` and `swap_indices` methods that work like the
top-level `IndexMap` methods using the current index of the entry.

For `VacantEntry` this adds `shift_insert`, while `RawVacantEntryMut`
adds `shift_insert` and `shift_insert_hashed_nocheck`, offering a way to
insert at a particular index while shifting other entries as needed.

Finally, for `IndexMap` and `IndexSet` this adds `shift_insert` using
`OccupiedEntry::move_index` or `VacantEntry::shift_insert`.