### PR TITLE
Add `insert_sorted`

### DIFF
--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -310,6 +310,24 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
         &mut map.entries[i].value
     }
 
+    /// Inserts the entry's key and the given value into the map at its ordered
+    /// position among sorted keys, and returns the new index and a mutable
+    /// reference to the value.
+    ///
+    /// If the existing keys are **not** already sorted, then the insertion
+    /// index is unspecified (like [`slice::binary_search`]), but the key-value
+    /// pair is inserted at that position regardless.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn insert_sorted(self, value: V) -> (usize, &'a mut V)
+    where
+        K: Ord,
+    {
+        let slice = crate::map::Slice::from_slice(&self.map.entries);
+        let i = slice.binary_search_keys(&self.key).unwrap_err();
+        (i, self.shift_insert(i, value))
+    }
+
     /// Inserts the entry's key and the given value into the map at the given index,
     /// shifting others to the right, and returns a mutable reference to the value.
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -355,6 +355,32 @@ where
         (index, existing.is_none())
     }
 
+    /// Insert the value into the set at its ordered position among sorted values.
+    ///
+    /// This is equivalent to finding the position with
+    /// [`binary_search`][Self::binary_search], and if needed calling
+    /// [`shift_insert`][Self::shift_insert] for a new value.
+    ///
+    /// If the sorted item is found in the set, it returns the index of that
+    /// existing item and `false`, without any change. Otherwise, it inserts the
+    /// new item and returns its sorted index and `true`.
+    ///
+    /// If the existing items are **not** already sorted, then the insertion
+    /// index is unspecified (like [`slice::binary_search`]), but the value
+    /// is moved to or inserted at that position regardless.
+    ///
+    /// Computes in **O(n)** time (average). Instead of repeating calls to
+    /// `insert_sorted`, it may be faster to call batched [`insert`][Self::insert]
+    /// or [`extend`][Self::extend] and only call [`sort`][Self::sort] or
+    /// [`sort_unstable`][Self::sort_unstable] once.
+    pub fn insert_sorted(&mut self, value: T) -> (usize, bool)
+    where
+        T: Ord,
+    {
+        let (index, existing) = self.map.insert_sorted(value, ());
+        (index, existing.is_none())
+    }
+
     /// Insert the value into the set at the given index.
     ///
     /// If an equivalent item already exists in the set, it returns
@@ -669,6 +695,10 @@ impl<T, S> IndexSet<T, S> {
     }
 
     /// Sort the set’s values by their default ordering.
+    ///
+    /// This is a stable sort -- but equivalent values should not normally coexist in
+    /// a set at all, so [`sort_unstable`][Self::sort_unstable] is preferred
+    /// because it is generally faster and doesn't allocate auxiliary memory.
     ///
     /// See [`sort_by`](Self::sort_by) for details.
     pub fn sort(&mut self)

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -113,6 +113,23 @@ quickcheck_limit! {
         true
     }
 
+    fn insert_sorted(insert: Vec<(u32, u32)>) -> bool {
+        let mut hmap = HashMap::new();
+        let mut map = IndexMap::new();
+        let mut map2 = IndexMap::new();
+        for &(key, value) in &insert {
+            hmap.insert(key, value);
+            map.insert_sorted(key, value);
+            match map2.entry(key) {
+                Entry::Occupied(e) => *e.into_mut() = value,
+                Entry::Vacant(e) => { e.insert_sorted(value); }
+            }
+        }
+        itertools::assert_equal(hmap.iter().sorted(), &map);
+        itertools::assert_equal(&map, &map2);
+        true
+    }
+
     fn pop(insert: Vec<u8>) -> bool {
         let mut map = IndexMap::new();
         for &key in &insert {


### PR DESCRIPTION
```rust
impl<K: Hash + Ord, V, S: BuildHasher> IndexMap<K, V, S> {
    pub fn insert_sorted(&mut self, key: K, value: V) -> (usize, Option<V>);
}
impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
    pub fn insert_sorted(self, value: V) -> (usize, &'a mut V);
}
impl<T: Hash + Ord, S: BuildHasher> IndexSet<T, S> {
    pub fn insert_sorted(&mut self, value: T) -> (usize, bool);
}
```

These use a `binary_search` to find the sorted index, then `shift_insert`, so they are O(n) overall. The insertion index is unspecified if the existing entries are not already sorted, but it will still act like a consistent `shift_insert` at that point.

Closes #89.