### PR TITLE
Add hash implementation

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1415,3 +1415,22 @@ where
     S: BuildHasher,
 {
 }
+
+#[cfg(feature = "std")]
+impl<K, V, S> Hash for IndexMap<K, V, S>
+where
+    K: Hash + std::fmt::Debug,
+    V: Hash + std::fmt::Debug,
+    S: BuildHasher,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let hash = self.as_slice().iter().map(|(k, v)| {
+            let mut hasher = std::hash::DefaultHasher::new();
+            k.hash(&mut hasher);
+            v.hash(&mut hasher);
+            hasher.finish()
+        }).fold(0, u64::wrapping_add);
+
+        state.write_u64(hash);
+    }
+}

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::string::String;
+use std::{hash::DefaultHasher, string::String};
 
 #[test]
 fn it_works() {
@@ -295,6 +295,30 @@ fn partial_eq_and_eq() {
     assert_ne!(map_a, map_c);
     assert_ne!(map_c, map_a);
 }
+
+#[test]
+fn hash() {
+    let mut map_a = IndexMap::new();
+    map_a.insert(1, "1");
+    map_a.insert(2, "2");
+    let mut map_b = IndexMap::new();
+    map_b.insert(1, "1");
+    map_b.insert(2, "2");
+    let mut map_c = IndexMap::new();
+    map_c.insert(1, "1");
+    map_c.insert(3, "3");
+
+    let mut hasher_a = DefaultHasher::new();
+    <IndexMap<i32, &str> as Hash>::hash(&map_a, &mut hasher_a);
+    let mut hasher_b = DefaultHasher::new();
+    <IndexMap<i32, &str> as Hash>::hash(&map_b, &mut hasher_b);
+    let mut hasher_c = DefaultHasher::new();
+    <IndexMap<i32, &str> as Hash>::hash(&map_c, &mut hasher_c);
+
+    assert_eq!(hasher_a.finish(), hasher_b.finish());
+    assert_ne!(hasher_a.finish(), hasher_c.finish());
+}
+
 
 #[test]
 fn extend() {

--- a/src/set.rs
+++ b/src/set.rs
@@ -25,7 +25,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
-use core::hash::{BuildHasher, Hash};
+use core::hash::{BuildHasher, Hash, Hasher};
 use core::ops::{BitAnd, BitOr, BitXor, Index, RangeBounds, Sub};
 
 use super::{Entries, Equivalent, IndexMap};
@@ -1067,6 +1067,18 @@ where
     S: BuildHasher,
 {
 }
+
+#[cfg(feature = "std")]
+impl<T, S> Hash for IndexSet<T, S>
+where
+    T: Hash + std::fmt::Debug,
+    S: BuildHasher,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        <IndexMap<T, (), S> as Hash>::hash(&self.map, state)
+    }
+}
+
 
 impl<T, S> IndexSet<T, S>
 where


### PR DESCRIPTION
There were several requests to implement `Hash` for `IndexMap` and `IndexSet`. The problem with implementing `Hash` is that it should be consistent with the `Eq` implementation. The `Eq` implementation is based on containing equivalent items *regardless of order*, requiring the hash to stay the same regardless of order. To fix this issue, one comment https://github.com/indexmap-rs/indexmap/issues/67#issuecomment-368576339 suggests using a commutative operation to combine the hashes of the individual entries.

This draft is an implementation of this proposal.