### PR TITLE
Add `just`:  new constructor to `IndexSet` and `IndexMap` respectively

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1295,6 +1295,17 @@ impl<K, V, S> IndexMut<usize> for IndexMap<K, V, S> {
     }
 }
 
+impl<K, V, S> IndexMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    /// Create an `IndexMap` from the key-value pair.
+    pub fn just(pair: (K, V)) -> Self {
+        Self::from_iter([pair])
+    }
+}
+
 impl<K, V, S> FromIterator<(K, V)> for IndexMap<K, V, S>
 where
     K: Hash + Eq,

--- a/src/set.rs
+++ b/src/set.rs
@@ -996,6 +996,17 @@ where
     }
 }
 
+impl<T, S> IndexSet<T, S>
+where
+    T: Hash + Eq,
+    S: BuildHasher + Default,
+{
+    /// Create a new set with the single `element`
+    pub fn just(element: T) -> Self {
+        Self::from_iter([element])
+    }
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T, const N: usize> From<[T; N]> for IndexSet<T, RandomState>

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,16 @@
-use indexmap::{indexmap, indexset};
+use indexmap::{indexmap, indexset, IndexMap, IndexSet};
+
+#[test]
+fn test_set_just() {
+    let s = IndexSet::<u8>::just(42);
+    assert_eq!(s, indexset!(42));
+}
+
+#[test]
+fn test_map_just() {
+    let m = IndexMap::<u8, u16>::just((42, 1337));
+    assert_eq!(m.get(&42), Some(&1337));
+}
 
 #[test]
 fn test_sort() {


### PR DESCRIPTION
Adding a new constructor to IndexMap and IndexSet respectively: `just` accepting a single element.

# Rationale
The `indexset!` macro is great, but I did not know about it until just now, while implementing this PR. I think a **named constructor** has a visibility benefit, that merits its existence. I think a common Developer Experience is to discover constructors using code completion, using turbo fish. 

[Also the docs of indexset type](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html#), does not even mention the macro - which ofc can be rectified with an update to the docs....

Constructors are also a crucial building in fuctional paradigms, such as `map`, here is an example:

```rust
assert_eq!(
    "42".parse::<u8>().map(IndexSet::<_>::just).unwrap(),
    indexset!(42)
);
```

Here we can map the `Result<u8, _>` to `IndexSet<u8>` using the new constructor `just`, and we note that **of course this does not work with the `indexset!` macro**:

```rust
assert_eq!(
    "42".parse::<u8>().map(indexset).unwrap(), // ‼️ expected value, found macro `indexset`, not a value
    indexset!(42)
);
```

# Alternative
Other alternative names considered instead of `just`:
* `single`
* `only`
* `with`
* Or `from_just`, `from_single`, `from_only`
* Or `with_just`, `with_single`, `with_only`

But I deemed `just` most convenient and yet still clear.