### PR TITLE
Use `serde_derive` via `derive` feature on `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"
 fxhash = "0.2.1"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! # use indexmap::IndexMap;
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{Deserialize, Serialize};
 //! #[derive(Deserialize, Serialize)]
 //! struct Data {
 //!     #[serde(with = "indexmap::map::serde_seq")]
@@ -66,7 +66,7 @@ where
 ///
 /// ```
 /// # use indexmap::IndexMap;
-/// # use serde_derive::Serialize;
+/// # use serde::Serialize;
 /// #[derive(Serialize)]
 /// struct Data {
 ///     #[serde(serialize_with = "indexmap::map::serde_seq::serialize")]
@@ -119,7 +119,7 @@ where
 ///
 /// ```
 /// # use indexmap::IndexMap;
-/// # use serde_derive::Deserialize;
+/// # use serde::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Data {
 ///     #[serde(deserialize_with = "indexmap::map::serde_seq::deserialize")]


### PR DESCRIPTION
This is the recommended way to do this in the `serde` docs.