### PR TITLE
Implement `From` between `IndexedEntry` and `OccupiedEntry`

### DIFF
--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -282,6 +282,17 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for OccupiedEntry<'_, K, V> {
     }
 }
 
+impl<'a, K, V> From<IndexedEntry<'a, K, V>> for OccupiedEntry<'a, K, V> {
+    fn from(entry: IndexedEntry<'a, K, V>) -> Self {
+        Self {
+            raw: entry
+                .map
+                .index_raw_entry(entry.index)
+                .expect("index not found"),
+        }
+    }
+}
+
 /// A view into a vacant entry in an [`IndexMap`][crate::IndexMap].
 /// It is part of the [`Entry`] enum.
 pub struct VacantEntry<'a, K, V> {
@@ -489,5 +500,12 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IndexedEntry<'_, K, V> {
             .field("key", self.key())
             .field("value", self.get())
             .finish()
+    }
+}
+
+impl<'a, K, V> From<OccupiedEntry<'a, K, V>> for IndexedEntry<'a, K, V> {
+    fn from(entry: OccupiedEntry<'a, K, V>) -> Self {
+        let (map, index) = entry.raw.into_inner();
+        Self { map, index }
     }
 }

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -417,6 +417,31 @@ fn get_index_entry() {
 }
 
 #[test]
+fn from_entries() {
+    let mut map = IndexMap::from([(1, "1"), (2, "2"), (3, "3")]);
+
+    {
+        let e = match map.entry(1) {
+            Entry::Occupied(e) => IndexedEntry::from(e),
+            Entry::Vacant(_) => panic!(),
+        };
+        assert_eq!(e.index(), 0);
+        assert_eq!(*e.key(), 1);
+        assert_eq!(*e.get(), "1");
+    }
+
+    {
+        let e = match map.get_index_entry(1) {
+            Some(e) => OccupiedEntry::from(e),
+            None => panic!(),
+        };
+        assert_eq!(e.index(), 1);
+        assert_eq!(*e.key(), 2);
+        assert_eq!(*e.get(), "2");
+    }
+}
+
+#[test]
 fn keys() {
     let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
     let map: IndexMap<_, _> = vec.into_iter().collect();


### PR DESCRIPTION
* `From<OccupiedEntry> for IndexedEntry` is trivially O(1).
* `From<IndexedEntry> for OccupiedEntry` is O(1) *average*, requiring a `RawTable` search for the bucket.

Either way, there's not much reason to convert unless you're normalizing different lookup results somewhere, but it's easy enough to support this that we might as well.