### PR TITLE
Add a few nods to `BTreeMap`/`Set`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1098,6 +1098,13 @@ impl<K, V, S> IndexMap<K, V, S> {
         self.as_entries_mut().first_mut().map(Bucket::ref_mut)
     }
 
+    /// Get the first entry in the map for in-place manipulation.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn first_entry(&mut self) -> Option<IndexedEntry<'_, K, V>> {
+        self.get_index_entry(0)
+    }
+
     /// Get the last key-value pair
     ///
     /// Computes in **O(1)** time.
@@ -1110,6 +1117,13 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Computes in **O(1)** time.
     pub fn last_mut(&mut self) -> Option<(&K, &mut V)> {
         self.as_entries_mut().last_mut().map(Bucket::ref_mut)
+    }
+
+    /// Get the last entry in the map for in-place manipulation.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn last_entry(&mut self) -> Option<IndexedEntry<'_, K, V>> {
+        self.get_index_entry(self.len().checked_sub(1)?)
     }
 
     /// Remove the key-value pair by index

--- a/src/map.rs
+++ b/src/map.rs
@@ -821,6 +821,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// This preserves the order of the remaining elements.
     ///
     /// Computes in **O(1)** time (average).
+    #[doc(alias = "pop_last")] // like `BTreeMap`
     pub fn pop(&mut self) -> Option<(K, V)> {
         self.core.pop()
     }
@@ -1087,6 +1088,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Get the first key-value pair
     ///
     /// Computes in **O(1)** time.
+    #[doc(alias = "first_key_value")] // like `BTreeMap`
     pub fn first(&self) -> Option<(&K, &V)> {
         self.as_entries().first().map(Bucket::refs)
     }
@@ -1108,6 +1110,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Get the last key-value pair
     ///
     /// Computes in **O(1)** time.
+    #[doc(alias = "last_key_value")] // like `BTreeMap`
     pub fn last(&self) -> Option<(&K, &V)> {
         self.as_entries().last().map(Bucket::refs)
     }

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -391,6 +391,8 @@ fn get_index_entry() {
     let mut map = IndexMap::new();
 
     assert!(map.get_index_entry(0).is_none());
+    assert!(map.first_entry().is_none());
+    assert!(map.last_entry().is_none());
 
     map.insert(0, "0");
     map.insert(1, "1");
@@ -414,6 +416,18 @@ fn get_index_entry() {
     }
 
     assert_eq!(*map.get(&3).unwrap(), "4");
+
+    {
+        let e = map.first_entry().unwrap();
+        assert_eq!(*e.key(), 0);
+        assert_eq!(*e.get(), "0");
+    }
+
+    {
+        let e = map.last_entry().unwrap();
+        assert_eq!(*e.key(), 2);
+        assert_eq!(*e.get(), "2");
+    }
 }
 
 #[test]

--- a/src/set.rs
+++ b/src/set.rs
@@ -708,6 +708,7 @@ impl<T, S> IndexSet<T, S> {
     /// This preserves the order of the remaining elements.
     ///
     /// Computes in **O(1)** time (average).
+    #[doc(alias = "pop_last")] // like `BTreeSet`
     pub fn pop(&mut self) -> Option<T> {
         self.map.pop().map(|(x, ())| x)
     }


### PR DESCRIPTION
- Add `first_entry` and `last_entry` similar to `BTreeMap`'s, except ours returns `IndexedEntry` instead of `OccupiedEntry`, avoiding the `RawTable` search.
- Add doc aliases for `BTreeMap`/`BTreeSet`-like methods:
  - `first_key_value` is `first`, and `last_key_value` is `last`
  - `pop_last` is just `pop` (and we don't have `pop_first`)
