### PR TITLE
Add `{Entry,VacantEntry}::insert_entry`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.6.0"
+version = "2.7.0"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 2.7.0 (2024-11-30)
+
+- Added methods `Entry::insert_entry` and `VacantEntry::insert_entry`, returning
+  an `OccupiedEntry` after insertion.
+
 ## 2.6.0 (2024-10-01)
 
 - Implemented `Clone` for `map::IntoIter` and `set::IntoIter`.

--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -39,6 +39,19 @@ impl<'a, K, V> Entry<'a, K, V> {
         }
     }
 
+    /// Sets the value of the entry (after inserting if vacant), and returns an `OccupiedEntry`.
+    ///
+    /// Computes in **O(1)** time (amortized average).
+    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
+        match self {
+            Entry::Occupied(mut entry) => {
+                entry.insert(value);
+                entry
+            }
+            Entry::Vacant(entry) => entry.insert_entry(value),
+        }
+    }
+
     /// Inserts the given default value in the entry if it is vacant and returns a mutable
     /// reference to it. Otherwise a mutable reference to an already existent value is returned.
     ///
@@ -136,6 +149,13 @@ pub struct OccupiedEntry<'a, K, V> {
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    pub(crate) fn new(
+        entries: &'a mut Entries<K, V>,
+        index: hash_table::OccupiedEntry<'a, usize>,
+    ) -> Self {
+        Self { entries, index }
+    }
+
     /// Return the index of the key-value pair
     #[inline]
     pub fn index(&self) -> usize {
@@ -180,6 +200,11 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn into_mut(self) -> &'a mut V {
         let index = self.index();
         &mut self.entries[index].value
+    }
+
+    pub(super) fn into_muts(self) -> (&'a mut K, &'a mut V) {
+        let index = self.index();
+        self.entries[index].muts()
     }
 
     /// Sets the value of the entry to `value`, and returns the entry's old value.
@@ -343,9 +368,18 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
 
     /// Inserts the entry's key and the given value into the map, and returns a mutable reference
     /// to the value.
-    pub fn insert(mut self, value: V) -> &'a mut V {
-        let i = self.map.insert_unique(self.hash, self.key, value);
-        &mut self.map.entries[i].value
+    ///
+    /// Computes in **O(1)** time (amortized average).
+    pub fn insert(self, value: V) -> &'a mut V {
+        self.insert_entry(value).into_mut()
+    }
+
+    /// Inserts the entry's key and the given value into the map, and returns an `OccupiedEntry`.
+    ///
+    /// Computes in **O(1)** time (amortized average).
+    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
+        let Self { map, hash, key } = self;
+        map.insert_unique(hash, key, value)
     }
 
     /// Inserts the entry's key and the given value into the map at its ordered

--- a/src/map/core/raw_entry_v1.rs
+++ b/src/map/core/raw_entry_v1.rs
@@ -618,10 +618,9 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
 
     /// Inserts the given key and value into the map with the provided hash,
     /// and returns mutable references to them.
-    pub fn insert_hashed_nocheck(mut self, hash: u64, key: K, value: V) -> (&'a mut K, &'a mut V) {
+    pub fn insert_hashed_nocheck(self, hash: u64, key: K, value: V) -> (&'a mut K, &'a mut V) {
         let hash = HashValue(hash as usize);
-        let i = self.map.insert_unique(hash, key, value);
-        self.map.entries[i].muts()
+        self.map.insert_unique(hash, key, value).into_muts()
     }
 
     /// Inserts the given key and value into the map at the given index,


### PR DESCRIPTION
This matches the `HashMap` side of rust-lang/rust#65225, which is stabilizing in Rust 1.83.