### PR TITLE
Mention cyclic dependency in main rustdocs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,11 @@
 //!   (de)serializing [`IndexMap`] as an ordered sequence are available in the
 //!   [`map::serde_seq`] module.
 //! * `borsh`: Adds implementations for [`BorshSerialize`] and [`BorshDeserialize`]
-//!   to [`IndexMap`] and [`IndexSet`].
+//!   to [`IndexMap`] and [`IndexSet`]. **Note:** When this feature is enabled,
+//!   you cannot enable the `derive` feature of [`borsh`] due to a cyclic
+//!   dependency. Instead, add the `borsh-derive` crate as an explicit
+//!   dependency in your Cargo.toml and import as e.g.
+//!   `use borsh_derive::{BorshSerialize, BorshDeserialize};`.
 //! * `arbitrary`: Adds implementations for the [`arbitrary::Arbitrary`] trait
 //!   to [`IndexMap`] and [`IndexSet`].
 //! * `quickcheck`: Adds implementations for the [`quickcheck::Arbitrary`] trait
@@ -50,6 +54,7 @@
 //! [`Deserialize`]: `::serde::Deserialize`
 //! [`BorshSerialize`]: `::borsh::BorshSerialize`
 //! [`BorshDeserialize`]: `::borsh::BorshDeserialize`
+//! [`borsh`]: `::borsh`
 //! [`arbitrary::Arbitrary`]: `::arbitrary::Arbitrary`
 //! [`quickcheck::Arbitrary`]: `::quickcheck::Arbitrary`
 //!


### PR DESCRIPTION
If a project has the following in its manifest:

```
[dependencies]
borsh = { version = "1.5.3", features = ["derive"] }
indexmap = { version = "2.7.0", features = ["borsh"] }
```

then the following error is returned by `cargo`:

```
error: cyclic package dependency: package `borsh v1.5.3` depends on itself. Cycle:
package `borsh v1.5.3`
    ... which satisfies dependency `borsh = "^1.2"` (locked to 1.5.3) of package `indexmap v2.7.0`
    ... which satisfies dependency `indexmap = "^2.3.0"` (locked to 2.7.0) of package `toml_edit v0.22.22`
    ... which satisfies dependency `toml_edit = "^0.22.20"` (locked to 0.22.22) of package `proc-macro-crate v3.2.0`
    ... which satisfies dependency `proc-macro-crate = "^3"` (locked to 3.2.0) of package `borsh-derive v1.5.3`
    ... which satisfies dependency `borsh-derive = "~1.5.3"` (locked to 1.5.3) of package `borsh v1.5.3`
```

The cycle can be broken by *not* enabling the `derive` feature of `borsh`, and instead just directly specifying the `borsh-derive` crate, e.g.

```
[dependencies]
borsh = "1.5.3"
borsh-derive = "1.5.3"
indexmap = { version = "2.7.0", features = ["borsh"] }
```

This only works as long as no other dependency (direct or transient) enables the `derive` feature of `borsh`.  In that case, I think the only way to break the cycle is to *not* enable the `borsh` feature of `indexmap`, likely requiring implementing the `borsh` traits by hand on the types holding `indexmap` members.