### PR TITLE
remove fxhash example and dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ rand = {version = "0.8", features = ["small_rng"] }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"
-fxhash = "0.2.1"
 serde_derive = "1.0"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,20 +68,14 @@
 //!
 //! ```
 //! use fnv::FnvBuildHasher;
-//! use fxhash::FxBuildHasher;
 //! use indexmap::{IndexMap, IndexSet};
 //!
 //! type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 //! type FnvIndexSet<T> = IndexSet<T, FnvBuildHasher>;
 //!
-//! type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
-//! type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;
-//!
 //! let std: IndexSet<i32> = (0..100).collect();
 //! let fnv: FnvIndexSet<i32> = (0..100).collect();
-//! let fx: FxIndexSet<i32> = (0..100).collect();
 //! assert_eq!(std, fnv);
-//! assert_eq!(std, fx);
 //! ```
 //!
 //! ### Rust Version


### PR DESCRIPTION
remove fxhash example and dep as [fxhash is unmaintained](https://github.com/rustsec/advisory-db/issues/2185) 