### PR TITLE
`impl PartialEq` between `Slice` and `[]`/arrays

### DIFF
--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -341,6 +341,22 @@ impl<K: PartialEq, V: PartialEq> PartialEq for Slice<K, V> {
     }
 }
 
+impl<K: PartialEq, V: PartialEq> PartialEq<[(K, V)]> for Slice<K, V> {
+    fn eq(&self, other: &[(K, V)]) -> bool {
+        self.len() == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+    }
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
+    fn eq(&self, other: &Slice<K, V>) -> bool {
+        self.len() == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().map(|(k, v)| (k, v)).eq(other)
+    }
+}
+
 impl<K: Eq, V: Eq> Eq for Slice<K, V> {}
 
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for Slice<K, V> {

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -2,7 +2,7 @@ use super::{
     Bucket, Entries, IndexMap, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values,
     ValuesMut,
 };
-use crate::util::try_simplify_range;
+use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -335,41 +335,55 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Slice<K, V> {
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq for Slice<K, V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<K, V, K2, V2> PartialEq<Slice<K2, V2>> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        slice_eq(&self.entries, &other.entries, |b1, b2| {
+            b1.key == b2.key && b1.value == b2.value
+        })
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq<[(K, V)]> for Slice<K, V> {
-    fn eq(&self, other: &[(K, V)]) -> bool {
-        self.len() == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+impl<K, V, K2, V2> PartialEq<[(K2, V2)]> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &[(K2, V2)]) -> bool {
+        slice_eq(&self.entries, other, |b, t| b.key == t.0 && b.value == t.1)
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
-    fn eq(&self, other: &Slice<K, V>) -> bool {
-        self.len() == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().map(|(k, v)| (k, v)).eq(other)
+impl<K, V, K2, V2> PartialEq<Slice<K2, V2>> for [(K, V)]
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        slice_eq(self, &other.entries, |t, b| t.0 == b.key && t.1 == b.value)
     }
 }
 
-impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<[(K, V); N]> for Slice<K, V> {
-    fn eq(&self, other: &[(K, V); N]) -> bool {
-        self.len() == N &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+impl<K, V, K2, V2, const N: usize> PartialEq<[(K2, V2); N]> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &[(K2, V2); N]) -> bool {
+        <Self as PartialEq<[_]>>::eq(self, other)
     }
 }
 
-impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<Slice<K, V>> for [(K, V); N] {
-    fn eq(&self, other: &Slice<K, V>) -> bool {
-        N == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().map(|(k, v)| (k, v)).eq(other)
+impl<K, V, const N: usize, K2, V2> PartialEq<Slice<K2, V2>> for [(K, V); N]
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        <[_] as PartialEq<_>>::eq(self, other)
     }
 }
 

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -357,6 +357,22 @@ impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
     }
 }
 
+impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<[(K, V); N]> for Slice<K, V> {
+    fn eq(&self, other: &[(K, V); N]) -> bool {
+        self.len() == N &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+    }
+}
+
+impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<Slice<K, V>> for [(K, V); N] {
+    fn eq(&self, other: &Slice<K, V>) -> bool {
+        N == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().map(|(k, v)| (k, v)).eq(other)
+    }
+}
+
 impl<K: Eq, V: Eq> Eq for Slice<K, V> {}
 
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for Slice<K, V> {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -228,6 +228,18 @@ impl<T: PartialEq> PartialEq for Slice<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq<[T]> for Slice<T> {
+    fn eq(&self, other: &[T]) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
+impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
+    fn eq(&self, other: &Slice<T>) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
 impl<T: Eq> Eq for Slice<T> {}
 
 impl<T: PartialOrd> PartialOrd for Slice<T> {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,5 +1,5 @@
 use super::{Bucket, Entries, IndexSet, IntoIter, Iter};
-use crate::util::try_simplify_range;
+use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -222,33 +222,48 @@ impl<T: fmt::Debug> fmt::Debug for Slice<T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for Slice<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<Slice<U>> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        slice_eq(&self.entries, &other.entries, |b1, b2| b1.key == b2.key)
     }
 }
 
-impl<T: PartialEq> PartialEq<[T]> for Slice<T> {
-    fn eq(&self, other: &[T]) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<[U]> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &[U]) -> bool {
+        slice_eq(&self.entries, other, |b, o| b.key == *o)
     }
 }
 
-impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
-    fn eq(&self, other: &Slice<T>) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<Slice<U>> for [T]
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        slice_eq(self, &other.entries, |o, b| *o == b.key)
     }
 }
 
-impl<T: PartialEq, const N: usize> PartialEq<[T; N]> for Slice<T> {
-    fn eq(&self, other: &[T; N]) -> bool {
-        self.len() == N && self.iter().eq(other)
+impl<T, U, const N: usize> PartialEq<[U; N]> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &[U; N]) -> bool {
+        <Self as PartialEq<[U]>>::eq(self, other)
     }
 }
 
-impl<T: PartialEq, const N: usize> PartialEq<Slice<T>> for [T; N] {
-    fn eq(&self, other: &Slice<T>) -> bool {
-        N == other.len() && self.iter().eq(other)
+impl<T, const N: usize, U> PartialEq<Slice<U>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        <[T] as PartialEq<Slice<U>>>::eq(self, other)
     }
 }
 

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -240,6 +240,18 @@ impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
     }
 }
 
+impl<T: PartialEq, const N: usize> PartialEq<[T; N]> for Slice<T> {
+    fn eq(&self, other: &[T; N]) -> bool {
+        self.len() == N && self.iter().eq(other)
+    }
+}
+
+impl<T: PartialEq, const N: usize> PartialEq<Slice<T>> for [T; N] {
+    fn eq(&self, other: &Slice<T>) -> bool {
+        N == other.len() && self.iter().eq(other)
+    }
+}
+
 impl<T: Eq> Eq for Slice<T> {}
 
 impl<T: PartialOrd> PartialOrd for Slice<T> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,3 +56,23 @@ where
     }
     Some(start..end)
 }
+
+// Generic slice equality -- copied from the standard library but adding a custom comparator,
+// allowing for our `Bucket` wrapper on either or both sides.
+pub(crate) fn slice_eq<T, U>(left: &[T], right: &[U], eq: impl Fn(&T, &U) -> bool) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+
+    // Implemented as explicit indexing rather
+    // than zipped iterators for performance reasons.
+    // See PR https://github.com/rust-lang/rust/pull/116846
+    for i in 0..left.len() {
+        // bound checks are optimized away
+        if !eq(&left[i], &right[i]) {
+            return false;
+        }
+    }
+
+    true
+}


### PR DESCRIPTION
Added comparisons between `Slice` and bare slices and arrays:

```rust
impl<K, V, K2, V2> PartialEq<[(K2, V2)]> for map::Slice<K, V>
where
    K: PartialEq<K2>,
    V: PartialEq<V2>,

impl<K, V, K2, V2> PartialEq<map::Slice<K2, V2>> for [(K, V)]
where
    K: PartialEq<K2>,
    V: PartialEq<V2>,

impl<K, V, K2, V2, const N: usize> PartialEq<[(K2, V2); N]> for map::Slice<K, V>
where
    K: PartialEq<K2>,
    V: PartialEq<V2>,

impl<K, V, const N: usize, K2, V2> PartialEq<map::Slice<K2, V2>> for [(K, V); N]
where
    K: PartialEq<K2>,
    V: PartialEq<V2>,

impl<T, U> PartialEq<[U]> for set::Slice<T>
where
    T: PartialEq<U>,

impl<T, U> PartialEq<set::Slice<U>> for [T]
where
    T: PartialEq<U>,

impl<T, U, const N: usize> PartialEq<[U; N]> for set::Slice<T>
where
    T: PartialEq<U>,

impl<T, const N: usize, U> PartialEq<set::Slice<U>> for [T; N]
where
    T: PartialEq<U>,
```

Updated `Slice`-to-`Slice` with more generic RHS:

```rust
impl<K, V, K2, V2> PartialEq<map::Slice<K2, V2>> for map::Slice<K, V>
where
    K: PartialEq<K2>,
    V: PartialEq<V2>,

impl<T, U> PartialEq<set::Slice<U>> for set::Slice<T>
where
    T: PartialEq<U>,
```

Resolves #375
