### PR TITLE
docs: provide link to `core::hash::BuildHasherDefault` in `macros.rs` docs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 /// Create an [`IndexMap`][crate::IndexMap] from a list of key-value pairs
-/// and a `BuildHasherDefault`-wrapped custom hasher.
+/// and a [`BuildHasherDefault`][core::hash::BuildHasherDefault]-wrapped custom hasher.
 ///
 /// ## Example
 ///
@@ -73,7 +73,7 @@ macro_rules! indexmap {
 }
 
 /// Create an [`IndexSet`][crate::IndexSet] from a list of values
-/// and a `BuildHasherDefault`-wrapped custom hasher.
+/// and a [`BuildHasherDefault`][core::hash::BuildHasherDefault]-wrapped custom hasher.
 ///
 /// ## Example
 ///


### PR DESCRIPTION
Currently the doc for `indexmap_with_default` and `indexset_with_default` mention `core::hash::BuildHasherDefault` but don't provide any hyperlink to [its page](https://doc.rust-lang.org/beta/core/hash/struct.BuildHasherDefault.html). We can easily fix this so that it is easier for people to use the two macros.