### PR TITLE
Deprecate the "borsh" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ equivalent = { version = "1.0", default-features = false }
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-borsh = { version = "1.2", optional = true, default-features = false }
 rayon = { version = "1.9", optional = true }
+
+# deprecated: use borsh's "indexmap" feature instead.
+borsh = { version = "1.2", optional = true, default-features = false }
 
 [dependencies.hashbrown]
 version = "0.15.0"

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -12,6 +12,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate::map::IndexMap;
 use crate::set::IndexSet;
 
+// NOTE: the real `#[deprecated]` attribute doesn't work for trait implementations,
+// but we can get close by mimicking the message style for documentation.
+/// <div class="stab deprecated"><span class="emoji">👎</span><span>Deprecated: use borsh's <code>indexmap</code> feature instead.</span></div>
 impl<K, V, S> BorshSerialize for IndexMap<K, V, S>
 where
     K: BorshSerialize,
@@ -36,6 +39,7 @@ where
     }
 }
 
+/// <div class="stab deprecated"><span class="emoji">👎</span><span>Deprecated: use borsh's <code>indexmap</code> feature instead.</span></div>
 impl<K, V, S> BorshDeserialize for IndexMap<K, V, S>
 where
     K: BorshDeserialize + Eq + Hash,
@@ -50,6 +54,7 @@ where
     }
 }
 
+/// <div class="stab deprecated"><span class="emoji">👎</span><span>Deprecated: use borsh's <code>indexmap</code> feature instead.</span></div>
 impl<T, S> BorshSerialize for IndexSet<T, S>
 where
     T: BorshSerialize,
@@ -72,6 +77,7 @@ where
     }
 }
 
+/// <div class="stab deprecated"><span class="emoji">👎</span><span>Deprecated: use borsh's <code>indexmap</code> feature instead.</span></div>
 impl<T, S> BorshDeserialize for IndexSet<T, S>
 where
     T: BorshDeserialize + Eq + Hash,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,16 +35,15 @@
 //!   to [`IndexMap`] and [`IndexSet`]. Alternative implementations for
 //!   (de)serializing [`IndexMap`] as an ordered sequence are available in the
 //!   [`map::serde_seq`] module.
-//! * `borsh`: Adds implementations for [`BorshSerialize`] and [`BorshDeserialize`]
-//!   to [`IndexMap`] and [`IndexSet`]. **Note:** When this feature is enabled,
-//!   you cannot enable the `derive` feature of [`borsh`] due to a cyclic
-//!   dependency. Instead, add the `borsh-derive` crate as an explicit
-//!   dependency in your Cargo.toml and import as e.g.
-//!   `use borsh_derive::{BorshSerialize, BorshDeserialize};`.
 //! * `arbitrary`: Adds implementations for the [`arbitrary::Arbitrary`] trait
 //!   to [`IndexMap`] and [`IndexSet`].
 //! * `quickcheck`: Adds implementations for the [`quickcheck::Arbitrary`] trait
 //!   to [`IndexMap`] and [`IndexSet`].
+//! * `borsh` (**deprecated**): Adds implementations for [`BorshSerialize`] and
+//!   [`BorshDeserialize`] to [`IndexMap`] and [`IndexSet`]. Due to a cyclic
+//!   dependency that arose between [`borsh`] and `indexmap`, `borsh v1.5.6`
+//!   added an `indexmap` feature that should be used instead of enabling the
+//!   feature here.
 //!
 //! _Note: only the `std` feature is enabled by default._
 //!


### PR DESCRIPTION
The real `#[deprecated]` attribute doesn't work for trait implementations,
but we can get close by mimicking the message style for documentation.

Use the "indexmap" feature added in `borsh v1.5.6` instead, solving the circular dependency.

Fixes #383.