### PR TITLE
Fix Vulnerability RUSTSEC-2024-0402

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ rayon = { version = "1.9", optional = true }
 borsh = { version = "1.2", optional = true, default-features = false }
 
 [dependencies.hashbrown]
-version = "0.15.0"
+version = "0.15.3"
 default-features = false
 
 [dev-dependencies]
 itertools = "0.14"
-rand = {version = "0.9", features = ["small_rng"] }
+rand = { version = "0.9", features = ["small_rng"] }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"


### PR DESCRIPTION
Vulnerability found on hashbrown 0.15.0 https://osv.dev/vulnerability/RUSTSEC-2024-0402