### PR TITLE
Fix typo in changelog: "occured" → "occurred"

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@
 - Added a `get_disjoint_indices_mut` method to `IndexMap` and `map::Slice`,
   matching Rust 1.86's `get_disjoint_mut` method on slices.
 - Deprecated the `borsh` feature in favor of their own `indexmap` feature,
-  solving a cyclic dependency that occured via `borsh-derive`.
+  solving a cyclic dependency that occurred via `borsh-derive`.
 
 ## 2.8.0 (2025-03-10)
 


### PR DESCRIPTION


**Description:**  
This PR corrects a minor typo in the RELEASES.md file, changing "occured" to the correct spelling "occurred" for improved documentation quality. 