### PR TITLE
Remove the internal `trait Entries`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,6 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-use alloc::vec::{self, Vec};
-
 mod arbitrary;
 #[macro_use]
 mod macros;
@@ -201,16 +199,6 @@ impl<K, V> Bucket<K, V> {
     fn muts(&mut self) -> (&mut K, &mut V) {
         (&mut self.key, &mut self.value)
     }
-}
-
-trait Entries {
-    type Entry;
-    fn into_entries(self) -> Vec<Self::Entry>;
-    fn as_entries(&self) -> &[Self::Entry];
-    fn as_entries_mut(&mut self) -> &mut [Self::Entry];
-    fn with_entries<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut [Self::Entry]);
 }
 
 /// The error type for [`try_reserve`][IndexMap::try_reserve] methods.

--- a/src/map.rs
+++ b/src/map.rs
@@ -38,7 +38,7 @@ use std::collections::hash_map::RandomState;
 
 use self::core::IndexMapCore;
 use crate::util::{third, try_simplify_range};
-use crate::{Bucket, Entries, Equivalent, GetDisjointMutError, HashValue, TryReserveError};
+use crate::{Bucket, Equivalent, GetDisjointMutError, HashValue, TryReserveError};
 
 /// A hash table where the iteration order of the key-value pairs is independent
 /// of the hash values of the keys.
@@ -113,32 +113,6 @@ where
     }
 }
 
-impl<K, V, S> Entries for IndexMap<K, V, S> {
-    type Entry = Bucket<K, V>;
-
-    #[inline]
-    fn into_entries(self) -> Vec<Self::Entry> {
-        self.core.into_entries()
-    }
-
-    #[inline]
-    fn as_entries(&self) -> &[Self::Entry] {
-        self.core.as_entries()
-    }
-
-    #[inline]
-    fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
-        self.core.as_entries_mut()
-    }
-
-    fn with_entries<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut [Self::Entry]),
-    {
-        self.core.with_entries(f);
-    }
-}
-
 impl<K, V, S> fmt::Debug for IndexMap<K, V, S>
 where
     K: fmt::Debug,
@@ -203,6 +177,28 @@ impl<K, V, S> IndexMap<K, V, S> {
             core: IndexMapCore::new(),
             hash_builder,
         }
+    }
+
+    #[inline]
+    pub(crate) fn into_entries(self) -> Vec<Bucket<K, V>> {
+        self.core.into_entries()
+    }
+
+    #[inline]
+    pub(crate) fn as_entries(&self) -> &[Bucket<K, V>] {
+        self.core.as_entries()
+    }
+
+    #[inline]
+    pub(crate) fn as_entries_mut(&mut self) -> &mut [Bucket<K, V>] {
+        self.core.as_entries_mut()
+    }
+
+    pub(crate) fn with_entries<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut [Bucket<K, V>]),
+    {
+        self.core.with_entries(f);
     }
 
     /// Return the number of elements the map can hold without reallocating.

--- a/src/map/core.rs
+++ b/src/map/core.rs
@@ -11,15 +11,13 @@ mod entry;
 
 pub mod raw_entry_v1;
 
-use hashbrown::hash_table;
-
-use crate::vec::{self, Vec};
-use crate::TryReserveError;
+use alloc::vec::{self, Vec};
 use core::mem;
 use core::ops::RangeBounds;
+use hashbrown::hash_table;
 
 use crate::util::simplify_range;
-use crate::{Bucket, Equivalent, HashValue};
+use crate::{Bucket, Equivalent, HashValue, TryReserveError};
 
 type Indices = hash_table::HashTable<usize>;
 type Entries<K, V> = Vec<Bucket<K, V>>;
@@ -109,33 +107,6 @@ where
     }
 }
 
-impl<K, V> crate::Entries for IndexMapCore<K, V> {
-    type Entry = Bucket<K, V>;
-
-    #[inline]
-    fn into_entries(self) -> Vec<Self::Entry> {
-        self.entries
-    }
-
-    #[inline]
-    fn as_entries(&self) -> &[Self::Entry] {
-        &self.entries
-    }
-
-    #[inline]
-    fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
-        &mut self.entries
-    }
-
-    fn with_entries<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut [Self::Entry]),
-    {
-        f(&mut self.entries);
-        self.rebuild_hash_table();
-    }
-}
-
 impl<K, V> IndexMapCore<K, V> {
     /// The maximum capacity before the `entries` allocation would exceed `isize::MAX`.
     const MAX_ENTRIES_CAPACITY: usize = (isize::MAX as usize) / mem::size_of::<Bucket<K, V>>();
@@ -159,6 +130,29 @@ impl<K, V> IndexMapCore<K, V> {
             indices: Indices::with_capacity(n),
             entries: Vec::with_capacity(n),
         }
+    }
+
+    #[inline]
+    pub(crate) fn into_entries(self) -> Entries<K, V> {
+        self.entries
+    }
+
+    #[inline]
+    pub(crate) fn as_entries(&self) -> &[Bucket<K, V>] {
+        &self.entries
+    }
+
+    #[inline]
+    pub(crate) fn as_entries_mut(&mut self) -> &mut [Bucket<K, V>] {
+        &mut self.entries
+    }
+
+    pub(crate) fn with_entries<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut [Bucket<K, V>]),
+    {
+        f(&mut self.entries);
+        self.rebuild_hash_table();
     }
 
     #[inline]

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -1,5 +1,5 @@
 use super::core::IndexMapCore;
-use super::{Bucket, Entries, IndexMap, Slice};
+use super::{Bucket, IndexMap, Slice};
 
 use alloc::vec::{self, Vec};
 use core::fmt;

--- a/src/map/mutable.rs
+++ b/src/map/mutable.rs
@@ -1,8 +1,7 @@
 use core::hash::{BuildHasher, Hash};
 
 use super::{
-    Bucket, Entries, Entry, Equivalent, IndexMap, IndexedEntry, IterMut2, OccupiedEntry,
-    VacantEntry,
+    Bucket, Entry, Equivalent, IndexMap, IndexedEntry, IterMut2, OccupiedEntry, VacantEntry,
 };
 
 /// Opt-in mutable access to [`IndexMap`] keys.

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,6 +1,5 @@
 use super::{
-    Bucket, Entries, IndexMap, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values,
-    ValuesMut,
+    Bucket, IndexMap, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut,
 };
 use crate::util::{slice_eq, try_simplify_range};
 use crate::GetDisjointMutError;

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -7,8 +7,8 @@ use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
-use crate::vec::Vec;
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
@@ -16,7 +16,6 @@ use core::ops::RangeBounds;
 
 use crate::map::Slice;
 use crate::Bucket;
-use crate::Entries;
 use crate::IndexMap;
 
 impl<K, V, S> IntoParallelIterator for IndexMap<K, V, S>

--- a/src/rayon/mod.rs
+++ b/src/rayon/mod.rs
@@ -3,8 +3,7 @@
 use rayon::prelude::*;
 
 use alloc::collections::LinkedList;
-
-use crate::vec::Vec;
+use alloc::vec::Vec;
 
 pub mod map;
 pub mod set;

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -7,15 +7,14 @@ use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
-use crate::vec::Vec;
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::ops::RangeBounds;
 
 use crate::set::Slice;
-use crate::Entries;
 use crate::IndexSet;
 
 type Bucket<T> = crate::Bucket<T, ()>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -28,7 +28,7 @@ use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::ops::{BitAnd, BitOr, BitXor, Index, RangeBounds, Sub};
 
-use super::{Entries, Equivalent, IndexMap};
+use super::{Equivalent, IndexMap};
 
 type Bucket<T> = super::Bucket<T, ()>;
 
@@ -105,32 +105,6 @@ where
     }
 }
 
-impl<T, S> Entries for IndexSet<T, S> {
-    type Entry = Bucket<T>;
-
-    #[inline]
-    fn into_entries(self) -> Vec<Self::Entry> {
-        self.map.into_entries()
-    }
-
-    #[inline]
-    fn as_entries(&self) -> &[Self::Entry] {
-        self.map.as_entries()
-    }
-
-    #[inline]
-    fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
-        self.map.as_entries_mut()
-    }
-
-    fn with_entries<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut [Self::Entry]),
-    {
-        self.map.with_entries(f);
-    }
-}
-
 impl<T, S> fmt::Debug for IndexSet<T, S>
 where
     T: fmt::Debug,
@@ -187,6 +161,23 @@ impl<T, S> IndexSet<T, S> {
         IndexSet {
             map: IndexMap::with_hasher(hash_builder),
         }
+    }
+
+    #[inline]
+    pub(crate) fn into_entries(self) -> Vec<Bucket<T>> {
+        self.map.into_entries()
+    }
+
+    #[inline]
+    pub(crate) fn as_entries(&self) -> &[Bucket<T>] {
+        self.map.as_entries()
+    }
+
+    pub(crate) fn with_entries<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut [Bucket<T>]),
+    {
+        self.map.with_entries(f);
     }
 
     /// Return the number of elements the set can hold without reallocating.

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -1,4 +1,4 @@
-use super::{Bucket, Entries, IndexSet, Slice};
+use super::{Bucket, IndexSet, Slice};
 
 use alloc::vec::{self, Vec};
 use core::fmt;

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,4 +1,4 @@
-use super::{Bucket, Entries, IndexSet, IntoIter, Iter};
+use super::{Bucket, IndexSet, IntoIter, Iter};
 use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;


### PR DESCRIPTION
This isn't doing anything for us that can't be done with `pub(crate)`
inherent methods instead.
