### PR TITLE
Remove Ord Trait Bound on insert_sorted_by Functions

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -507,7 +507,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, key: K, value: V, mut cmp: F) -> (usize, Option<V>)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         let (Ok(i) | Err(i)) = self.binary_search_by(|k, v| cmp(k, v, &key, &value));

--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -414,7 +414,6 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(self, value: V, mut cmp: F) -> (usize, &'a mut V)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         let slice = crate::map::Slice::from_slice(self.map.entries);

--- a/src/set.rs
+++ b/src/set.rs
@@ -436,7 +436,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, value: T, mut cmp: F) -> (usize, bool)
     where
-        T: Ord,
         F: FnMut(&T, &T) -> Ordering,
     {
         let (index, existing) = self


### PR DESCRIPTION
Removes the Ord trait bounds on insert_sorted_by functions as briefly discussed in issue #410.