### PR TITLE
Release 2.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.11.0"
+version = "2.11.1"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 2.11.1 (2025-09-08)
+
+- Added a `get_key_value_mut` method to `IndexMap`.
+- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.
+
 ## 2.11.0 (2025-08-22)
 
 - Added `insert_sorted_by` and `insert_sorted_by_key` methods to `IndexMap`,


### PR DESCRIPTION
- Added a `get_key_value_mut` method to `IndexMap`.
- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.