### PR TITLE
Depend on `serde_core` instead of `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ equivalent = { version = "1.0", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false }
+serde_core = { version = "1.0.220", optional = true, default-features = false }
 rayon = { version = "1.9", optional = true }
 sval = { version = "2", optional = true, default-features = false }
 
@@ -29,16 +29,22 @@ borsh = { version = "1.2", optional = true, default-features = false }
 version = "0.15.0"
 default-features = false
 
+# serde v1.0.220 is the first version that released with `serde_core`.
+# This is required to avoid conflict with other `serde` users which may require an older version.
+[target.'cfg(any())'.dependencies]
+serde = { version = "1.0.220", default-features = false }
+
 [dev-dependencies]
 itertools = "0.14"
 fastrand = { version = "2", default-features = false }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = []
+serde = ["dep:serde_core"]
 
 # for testing only, of course
 test_debug = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //! [`no_std`]: #no-standard-library-targets
-//! [`Serialize`]: `::serde::Serialize`
-//! [`Deserialize`]: `::serde::Deserialize`
+//! [`Serialize`]: `::serde_core::Serialize`
+//! [`Deserialize`]: `::serde_core::Deserialize`
 //! [`BorshSerialize`]: `::borsh::BorshSerialize`
 //! [`BorshDeserialize`]: `::borsh::BorshDeserialize`
 //! [`borsh`]: `::borsh`

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! # use indexmap::IndexMap;
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{Deserialize, Serialize};
 //! #[derive(Deserialize, Serialize)]
 //! struct Data {
 //!     #[serde(with = "indexmap::map::serde_seq")]
@@ -18,8 +18,8 @@
 //! }
 //! ```
 
-use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
-use serde::ser::{Serialize, Serializer};
+use serde_core::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde_core::ser::{Serialize, Serializer};
 
 use core::fmt::{self, Formatter};
 use core::hash::{BuildHasher, Hash};
@@ -66,7 +66,7 @@ where
 ///
 /// ```
 /// # use indexmap::IndexMap;
-/// # use serde_derive::Serialize;
+/// # use serde::Serialize;
 /// #[derive(Serialize)]
 /// struct Data {
 ///     #[serde(serialize_with = "indexmap::map::serde_seq::serialize")]
@@ -119,7 +119,7 @@ where
 ///
 /// ```
 /// # use indexmap::IndexMap;
-/// # use serde_derive::Deserialize;
+/// # use serde::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Data {
 ///     #[serde(deserialize_with = "indexmap::map::serde_seq::deserialize")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 
-use serde::de::value::{MapDeserializer, SeqDeserializer};
-use serde::de::{
+use serde_core::de::value::{MapDeserializer, SeqDeserializer};
+use serde_core::de::{
     Deserialize, Deserializer, Error, IntoDeserializer, MapAccess, SeqAccess, Visitor,
 };
-use serde::ser::{Serialize, Serializer};
+use serde_core::ser::{Serialize, Serializer};
 
 use core::fmt::{self, Formatter};
 use core::hash::{BuildHasher, Hash};


### PR DESCRIPTION
This crate does not make use of serde derive macros, thus it can depend on `serde_core` instead of `serde` to speed up users' compile times.

See the documentation of [`serde_core`](https://docs.rs/serde_core) for more details.