### PR TITLE
Release 2.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.11.1"
+version = "2.11.2"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 2.11.2 (2025-09-15)
+
+- Switched the "serde" feature to depend on `serde_core`, improving build
+  parallelism in cases where other dependents have enabled "serde/derive".
+
 ## 2.11.1 (2025-09-08)
 
 - Added a `get_key_value_mut` method to `IndexMap`.


### PR DESCRIPTION
- Switched the "serde" feature to depend on `serde_core`, improving build
  parallelism in cases where other dependents have enabled "serde/derive".