### PR TITLE
Release 2.11.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.11.2"
+version = "2.11.3"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"
@@ -32,7 +32,7 @@ default-features = false
 # serde v1.0.220 is the first version that released with `serde_core`.
 # This is required to avoid conflict with other `serde` users which may require an older version.
 [target.'cfg(any())'.dependencies]
-serde = { version = "1.0.220", default-features = false }
+serde = { version = "1.0.220", default-features = false, optional = true }
 
 [dev-dependencies]
 itertools = "0.14"
@@ -44,7 +44,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 [features]
 default = ["std"]
 std = []
-serde = ["dep:serde_core"]
+serde = ["dep:serde_core", "dep:serde"]
 
 # for testing only, of course
 test_debug = []

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 2.11.3 (2025-09-15)
+
+- Make the minimum `serde` version only apply when "serde" is enabled.
+
 ## 2.11.2 (2025-09-15)
 
 - Switched the "serde" feature to depend on `serde_core`, improving build


### PR DESCRIPTION
- Make the minimum `serde` version only apply when "serde" is enabled.