### PR TITLE
Use `BuildHasherDefault::new` in macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@
 macro_rules! indexmap_with_default {
     ($H:ty; $($key:expr => $value:expr,)+) => { $crate::indexmap_with_default!($H; $($key => $value),+) };
     ($H:ty; $($key:expr => $value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
         const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
         #[allow(unused_mut)]
         // Specify your custom `H` (must implement Default + Hasher) as the hasher:


### PR DESCRIPTION
This was already done for sets, but I missed maps. It doesn't really make any functional difference though.