### PR TITLE
Use a simpler `equal` closure for `Q = K`

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -39,6 +39,14 @@ fn get_hash<K, V>(entries: &[Bucket<K, V>]) -> impl Fn(&usize) -> u64 + use<'_, 
 }
 
 #[inline]
+fn equal<'a, K: Eq, V>(
+    key: &'a K,
+    entries: &'a [Bucket<K, V>],
+) -> impl Fn(&usize) -> bool + use<'a, K, V> {
+    move |&i| K::eq(key, &entries[i].key)
+}
+
+#[inline]
 fn equivalent<'a, K, V, Q: ?Sized + Equivalent<K>>(
     key: &'a Q,
     entries: &'a [Bucket<K, V>],
@@ -327,7 +335,7 @@ impl<K, V> Core<K, V> {
     where
         K: Eq,
     {
-        let eq = equivalent(&key, &self.entries);
+        let eq = equal(&key, &self.entries);
         let hasher = get_hash(&self.entries);
         match self.indices.entry(hash.get(), eq, hasher) {
             hash_table::Entry::Occupied(entry) => {
@@ -354,7 +362,7 @@ impl<K, V> Core<K, V> {
     where
         K: Eq,
     {
-        let eq = equivalent(&key, &self.entries);
+        let eq = equal(&key, &self.entries);
         let hasher = get_hash(&self.entries);
         match self.indices.entry(hash.get(), eq, hasher) {
             hash_table::Entry::Occupied(entry) => {

--- a/src/inner/entry.rs
+++ b/src/inner/entry.rs
@@ -1,4 +1,4 @@
-use super::{Bucket, Core, equivalent, get_hash};
+use super::{Bucket, Core, equal, get_hash};
 use crate::HashValue;
 use crate::map::{Entry, IndexedEntry};
 use core::cmp::Ordering;
@@ -9,7 +9,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     where
         K: Eq,
     {
-        let eq = equivalent(&key, &map.entries);
+        let eq = equal(&key, &map.entries);
         match map.indices.find_entry(hash.get(), eq) {
             Ok(entry) => Entry::Occupied(OccupiedEntry {
                 bucket: entry.bucket_index(),


### PR DESCRIPTION
There are cases where we never need the `Equivalent` abstraction. This may not lead to much performance difference, if any, but it should at least be a little lighter burden on the compiler.