### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -244,7 +244,7 @@ impl<K, V> Slice<K, V> {
         Values::new(&self.entries)
     }
 
-    /// Return an iterator over mutable references to the the values of the map slice.
+    /// Return an iterator over mutable references to the values of the map slice.
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut::new(&mut self.entries)
     }

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -394,7 +394,7 @@ where
     K: Send,
     V: Send,
 {
-    /// Return a parallel iterator over mutable references to the the values of the map slice.
+    /// Return a parallel iterator over mutable references to the values of the map slice.
     ///
     /// While parallel iterators can process items in any order, their relative order
     /// in the slice is still preserved for operations like `reduce` and `collect`.


### PR DESCRIPTION
Fix several typos found in source code comments and documentation strings.