### PR TITLE
Improve the map/set macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2024"
-version = "2.14.1"
+version = "2.14.2"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/indexmap-rs/indexmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 2.14.2 (2026-09-04)
+
+- Fix item hygiene in map and set macros. Previously, an internal `const CAP`
+  could shadow the same name in the caller's namespace.
+- Allow `const` initialization of empty `indexmap_with_default!` and
+  `indexset_with_default!`. The hasher may also be omitted if it's inferrable.
+
 ## 2.14.1 (2026-08-28)
 
 - Simplify comparisons where `Equivalent` isn't needed (`Q = K`).

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,11 +19,40 @@
 /// // "a" is the first key
 /// assert_eq!(map.keys().next(), Some(&"a"));
 /// ```
+///
+/// This can also be initialized in `const` contexts:
+///
+/// ```
+/// use indexmap::{IndexMap, indexmap_with_default};
+/// use fnv::FnvBuildHasher; // = BuildHasherDefault<FnvHasher>
+/// use std::sync::Mutex;
+///
+/// static GLOBAL: Mutex<IndexMap<String, i32, FnvBuildHasher>> =
+///     Mutex::new(indexmap_with_default!());
+///
+/// if let Ok(mut map) = GLOBAL.lock() {
+///     map.insert("a".into(), 1);
+///     map.insert("b".into(), 2);
+/// }
+///
+/// assert_eq!(GLOBAL.lock().unwrap()["a"], 1);
+/// assert_eq!(GLOBAL.lock().unwrap()["b"], 2);
+/// ```
 #[macro_export]
 macro_rules! indexmap_with_default {
-    ($H:ty; $($key:expr => $value:expr,)+) => { $crate::indexmap_with_default!($H; $($key => $value),+) };
-    ($H:ty; $($key:expr => $value:expr),*) => {{
-        #[allow(unused_mut)]
+    () => { const {
+        $crate::IndexMap::with_hasher(
+            // Let type inference figure out the hasher:
+            ::core::hash::BuildHasherDefault::new(),
+        )
+    }};
+    ($H:ty $(;)?) => { const {
+        $crate::IndexMap::with_hasher(
+            // Specify your custom `H` (must implement Default + Hasher) as the hasher:
+            ::core::hash::BuildHasherDefault::<$H>::new(),
+        )
+    }};
+    ($H:ty; $($key:expr => $value:expr),+ $(,)?) => {{
         let mut map = $crate::IndexMap::with_capacity_and_hasher(
             // Note: `stringify!($key)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
@@ -33,7 +62,7 @@ macro_rules! indexmap_with_default {
         );
         $(
             map.insert($key, $value);
-        )*
+        )+
         map
     }};
 }
@@ -60,8 +89,8 @@ macro_rules! indexmap_with_default {
 /// assert_eq!(map.keys().next(), Some(&"a"));
 /// ```
 macro_rules! indexmap {
-    ($($key:expr => $value:expr,)+) => { $crate::indexmap!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {{
+    () => { $crate::IndexMap::new() };
+    ($($key:expr => $value:expr),+ $(,)?) => {{
         let mut map = $crate::IndexMap::with_capacity(
             // Note: `stringify!($key)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
@@ -69,7 +98,7 @@ macro_rules! indexmap {
         );
         $(
             map.insert($key, $value);
-        )*
+        )+
         map
     }};
 }
@@ -95,21 +124,52 @@ macro_rules! indexmap {
 /// // "a" is the first value
 /// assert_eq!(set.iter().next(), Some(&"a"));
 /// ```
+///
+/// This can also be initialized in `const` contexts:
+///
+/// ```
+/// use indexmap::{IndexSet, indexset_with_default};
+/// use fnv::FnvBuildHasher; // = BuildHasherDefault<FnvHasher>
+/// use std::sync::Mutex;
+///
+/// static INTERN: Mutex<IndexSet<String, FnvBuildHasher>> =
+///     Mutex::new(indexset_with_default!());
+///
+/// if let Ok(mut set) = INTERN.lock() {
+///     set.insert("a".into());
+///     set.insert("b".into());
+///     set.insert("c".into());
+/// }
+///
+/// assert!(INTERN.lock().unwrap().contains("a"));
+/// assert!(INTERN.lock().unwrap().contains("b"));
+/// assert!(INTERN.lock().unwrap().contains("c"));
+/// ```
 #[macro_export]
 macro_rules! indexset_with_default {
-    ($H:ty; $($value:expr,)+) => { $crate::indexset_with_default!($H; $($value),+) };
-    ($H:ty; $($value:expr),*) => {{
-        #[allow(unused_mut)]
+    () => { const {
+        $crate::IndexSet::with_hasher(
+            // Let type inference figure out the hasher:
+            ::core::hash::BuildHasherDefault::new(),
+        )
+    }};
+    ($H:ty $(;)?) => { const {
+        $crate::IndexSet::with_hasher(
+            // Specify your custom `H` (must implement Default + Hasher) as the hasher:
+            ::core::hash::BuildHasherDefault::<$H>::new(),
+        )
+    }};
+    ($H:ty; $($value:expr),+ $(,)?) => {{
         let mut set = $crate::IndexSet::with_capacity_and_hasher(
             // Note: `stringify!($value)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
             const { <[()]>::len(&[$({ stringify!($value); }),*]) },
-            // Specify your custom `H` (must implement Default + Hash) as the hasher:
+            // Specify your custom `H` (must implement Default + Hasher) as the hasher:
             ::core::hash::BuildHasherDefault::<$H>::new(),
         );
         $(
             set.insert($value);
-        )*
+        )+
         set
     }};
 }
@@ -136,8 +196,8 @@ macro_rules! indexset_with_default {
 /// assert_eq!(set.iter().next(), Some(&"a"));
 /// ```
 macro_rules! indexset {
-    ($($value:expr,)+) => { $crate::indexset!($($value),+) };
-    ($($value:expr),*) => {{
+    () => { $crate::IndexSet::new() };
+    ($($value:expr),+ $(,)?) => {{
         let mut set = $crate::IndexSet::with_capacity(
             // Note: `stringify!($value)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
@@ -145,7 +205,7 @@ macro_rules! indexset {
         );
         $(
             set.insert($value);
-        )*
+        )+
         set
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,11 +23,14 @@
 macro_rules! indexmap_with_default {
     ($H:ty; $($key:expr => $value:expr,)+) => { $crate::indexmap_with_default!($H; $($key => $value),+) };
     ($H:ty; $($key:expr => $value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
-        const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
         #[allow(unused_mut)]
-        // Specify your custom `H` (must implement Default + Hasher) as the hasher:
-        let mut map = $crate::IndexMap::with_capacity_and_hasher(CAP, builder);
+        let mut map = $crate::IndexMap::with_capacity_and_hasher(
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const { <[()]>::len(&[$({ stringify!($key); }),*]) },
+            // Specify your custom `H` (must implement Default + Hasher) as the hasher:
+            ::core::hash::BuildHasherDefault::<$H>::new(),
+        );
         $(
             map.insert($key, $value);
         )*
@@ -58,18 +61,17 @@ macro_rules! indexmap_with_default {
 /// ```
 macro_rules! indexmap {
     ($($key:expr => $value:expr,)+) => { $crate::indexmap!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
-        {
+    ($($key:expr => $value:expr),*) => {{
+        let mut map = $crate::IndexMap::with_capacity(
             // Note: `stringify!($key)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
-            const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
-            let mut map = $crate::IndexMap::with_capacity(CAP);
-            $(
-                map.insert($key, $value);
-            )*
-            map
-        }
-    };
+            const { <[()]>::len(&[$({ stringify!($key); }),*]) },
+        );
+        $(
+            map.insert($key, $value);
+        )*
+        map
+    }};
 }
 
 /// Create an [`IndexSet`][crate::IndexSet] from a list of values
@@ -97,11 +99,14 @@ macro_rules! indexmap {
 macro_rules! indexset_with_default {
     ($H:ty; $($value:expr,)+) => { $crate::indexset_with_default!($H; $($value),+) };
     ($H:ty; $($value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
-        const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
         #[allow(unused_mut)]
-        // Specify your custom `H` (must implement Default + Hash) as the hasher:
-        let mut set = $crate::IndexSet::with_capacity_and_hasher(CAP, builder);
+        let mut set = $crate::IndexSet::with_capacity_and_hasher(
+            // Note: `stringify!($value)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const { <[()]>::len(&[$({ stringify!($value); }),*]) },
+            // Specify your custom `H` (must implement Default + Hash) as the hasher:
+            ::core::hash::BuildHasherDefault::<$H>::new(),
+        );
         $(
             set.insert($value);
         )*
@@ -132,18 +137,17 @@ macro_rules! indexset_with_default {
 /// ```
 macro_rules! indexset {
     ($($value:expr,)+) => { $crate::indexset!($($value),+) };
-    ($($value:expr),*) => {
-        {
+    ($($value:expr),*) => {{
+        let mut set = $crate::IndexSet::with_capacity(
             // Note: `stringify!($value)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
-            const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
-            let mut set = $crate::IndexSet::with_capacity(CAP);
-            $(
-                set.insert($value);
-            )*
-            set
-        }
-    };
+            const { <[()]>::len(&[$({ stringify!($value); }),*]) },
+        );
+        $(
+            set.insert($value);
+        )*
+        set
+    }};
 }
 
 // generate all the Iterator methods by just forwarding to the underlying

--- a/tests/macros_full_path.rs
+++ b/tests/macros_full_path.rs
@@ -17,3 +17,43 @@ fn test_create_set() {
         3,
     };
 }
+
+#[test]
+fn test_map_shadow() {
+    // The macro used to have its own `const CAP` which would shadow this, because items are not
+    // protected by macro hygiene. Now we avoid any items in the macro, and its local `map` *is*
+    // hygienic vs. the local `map` here.
+    const CAP: usize = 42;
+    let map = -1;
+    let m = indexmap::indexmap! {
+        map => CAP,
+    };
+    assert_eq!(m[&map], CAP);
+    assert_eq!(m[0], CAP);
+}
+
+#[test]
+fn test_map_shadow_default() {
+    const CAP: usize = 42;
+    let map = -1;
+    let m = indexmap::indexmap_with_default! {
+        fnv::FnvHasher;
+        map => CAP,
+    };
+    assert_eq!(m[&map], CAP);
+    assert_eq!(m[0], CAP);
+}
+
+#[test]
+fn test_set_shadow() {
+    const CAP: usize = 42;
+    let s = indexmap::indexset!(CAP);
+    assert_eq!(s[0], CAP);
+}
+
+#[test]
+fn test_set_shadow_default() {
+    const CAP: usize = 42;
+    let s = indexmap::indexset_with_default!(fnv::FnvHasher; CAP);
+    assert_eq!(s[0], CAP);
+}


### PR DESCRIPTION
* Fix item hygiene (no `CAP`)
* Allow empty collections to be `const`